### PR TITLE
Fix user avatar persistence after logout

### DIFF
--- a/frontend/src/components/header/navigation.tsx
+++ b/frontend/src/components/header/navigation.tsx
@@ -6,7 +6,7 @@ import { DefaultUserAvatarLogo, LongHabitMainLogo } from '../shared/logos'
 export default function Navigation() {
   const { user } = useAuth()
   const { avatar, id: userId, verified } = user ?? {}
-  const location = useLocation() // solves issue with persisting avatar after logout, but possibly not for much longer ? see: https://github.com/TanStack/router/issues/3110#issuecomment-2645886152
+  const location = useLocation()
 
   return (
     <nav className='flex items-center justify-between'>

--- a/frontend/src/components/header/navigation.tsx
+++ b/frontend/src/components/header/navigation.tsx
@@ -1,11 +1,12 @@
 import { Avatar, AvatarImage } from '@/components/ui/avatar'
 import useAuth from '@/hooks/use-auth'
-import { Link } from '@tanstack/react-router'
+import { Link, useLocation } from '@tanstack/react-router'
 import { DefaultUserAvatarLogo, LongHabitMainLogo } from '../shared/logos'
 
 export default function Navigation() {
   const { user } = useAuth()
   const { avatar, id: userId, verified } = user ?? {}
+  const location = useLocation() // solves issue with persisting avatar after logout, but possibly not for much longer ? see: https://github.com/TanStack/router/issues/3110#issuecomment-2645886152
 
   return (
     <nav className='flex items-center justify-between'>
@@ -17,7 +18,7 @@ export default function Navigation() {
         to={verified ? '/tasks/settings' : '/login'}
         className='focus:outline-none'>
         <Avatar className='flex size-10 items-center justify-center'>
-          {avatar ? (
+          {avatar && !location.search.logout ? (
             <AvatarImage
               src={`/api/files/users/${userId}/${avatar}?thumb=100x100`}
               alt='user avatar icon'

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -32,7 +32,7 @@ export default function useAuth() {
     logoutApi()
     queryClient.clear()
     unsubscribeFromUserChanges()
-    router.navigate({ to: '/' })
+    router.navigate({ to: '/', search: () => ({ logout: true }) })
   }
 
   const subscribeUserChangeCallback = async (record: User) => {

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -13,6 +13,7 @@ import {
 } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 import { useEffect } from 'react'
+import { z } from 'zod'
 import Spinner from './components/shared/spinner'
 import { setTheme } from './lib/set-theme'
 import ForgotPasswordPage from './pages/auth/forgot-password'
@@ -68,6 +69,10 @@ const rootRoute = createRootRouteWithContext<RootContext>()({
   component: RootLayoutWithTitle,
   notFoundComponent: NotFoundPage,
   errorComponent: ErrorPage,
+  validateSearch: z.object({
+    logout: z.boolean().optional()
+  }),
+
   loader: ({ context: { queryClient } }) =>
     queryClient.ensureQueryData(userQueryOptions),
   beforeLoad: async ({ context: { queryClient } }) => {


### PR DESCRIPTION
This PR fixes the issue #3 where the user avatar remains visible after logout until a hard refresh is performed. 

While simply calling `useLocation()` inside `navigation.tsx` could trigger a re-render and resolve the problem, the exact reason remains unclear. To ensure a reliable solution, the approach using the "logout" search parameter was chosen.